### PR TITLE
[FIX] jwt 토큰 관련 보안설정 프로덕션 환경에 맞게 수정

### DIFF
--- a/mindscape-auth/src/main/java/likelion/team1/mindscape/controller/AuthController.java
+++ b/mindscape-auth/src/main/java/likelion/team1/mindscape/controller/AuthController.java
@@ -80,16 +80,16 @@ public class AuthController {
             redisRefreshTokenService.deleteRefreshToken(principalDetails.getAccountId());
         }
 
+        // AccessToken 만료 처리
+        String expiredAccessToken = "AccessToken=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=None";
 
-        Cookie accessTokenCookie = new Cookie("AccessToken", "null");
-        accessTokenCookie.setMaxAge(0);
-        accessTokenCookie.setPath("/");
+        // RefreshToken 만료 처리
+        String expiredRefreshToken = "RefreshToken=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=None";
 
-        Cookie refreshTokenCookie = new Cookie("refreshToken", "null");
-        refreshTokenCookie.setMaxAge(0);
-        refreshTokenCookie.setPath("/");
+        // 응답 헤더로 만료 쿠키 추가
+        response.addHeader("Set-Cookie", expiredAccessToken);
+        response.addHeader("Set-Cookie", expiredRefreshToken);
 
-        response.addCookie(accessTokenCookie);
 
         return ResponseEntity.ok(HttpStatus.OK);
     }

--- a/mindscape-auth/src/main/java/likelion/team1/mindscape/security/CorsConfig.java
+++ b/mindscape-auth/src/main/java/likelion/team1/mindscape/security/CorsConfig.java
@@ -22,7 +22,9 @@ public class CorsConfig {
         config.setAllowCredentials(true);
 
         // 구체적인 origin을 설정
-        config.addAllowedOriginPattern("*");  // 개발 환경에서만 사용하세요
+//        config.addAllowedOriginPattern("*");  // 개발 환경에서만 사용하세요
+
+        config.addAllowedOrigin("https://aws.thejymes.com");
 
         // 모든 헤더와 메소드 허용
         config.addAllowedHeader("*");

--- a/mindscape-auth/src/main/java/likelion/team1/mindscape/security/jwt/JwtAuthorizationFilter.java
+++ b/mindscape-auth/src/main/java/likelion/team1/mindscape/security/jwt/JwtAuthorizationFilter.java
@@ -63,22 +63,22 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
                     .verify(accessToken)
                     .getSubject();
 
-           if(accountId != null) {
-               // 추출된 사용자가 현재 DB에 등록된 사용자인지 확인
-               User user = userRepository.findByAccountId(accountId);
+            if(accountId != null) {
+                // 추출된 사용자가 현재 DB에 등록된 사용자인지 확인
+                User user = userRepository.findByAccountId(accountId);
 
-               // 사용자 정보
-               PrincipalDetails principalDetails = new PrincipalDetails(user);
+                // 사용자 정보
+                PrincipalDetails principalDetails = new PrincipalDetails(user);
 
-               Authentication authentication =
-                       new UsernamePasswordAuthenticationToken(
-                               principalDetails, // 사용자 정보
-                               null, // 인증 완료로 비밀번호 불필요
-                               principalDetails.getAuthorities()); // 권한 정보
+                Authentication authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                principalDetails, // 사용자 정보
+                                null, // 인증 완료로 비밀번호 불필요
+                                principalDetails.getAuthorities()); // 권한 정보
 
-               //SecurityContext에 인증 정보 저장
-               SecurityContextHolder.getContext().setAuthentication(authentication);
-           }
+                //SecurityContext에 인증 정보 저장
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
         } catch (TokenExpiredException e){ // 토큰이 만료된 경우
 
             if(refreshToken != null) {
@@ -99,10 +99,10 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
                             .withExpiresAt(new Date(System.currentTimeMillis() + jwtProperties.getACCESS_TOKEN_EXPIRATION()))
                             .sign(Algorithm.HMAC512(jwtProperties.getSECRET()));
 
-                    Cookie newAccessTokenCookie = new Cookie(JwtProperties.ACCESS_TOKEN_STRING, newAccessToken);
-                    newAccessTokenCookie.setPath("/");
-                    newAccessTokenCookie.setHttpOnly(true);
-                    response.addCookie(newAccessTokenCookie);
+                    String accessCookie = String.format(
+                            "AccessToken=%s; Path=/; Max-Age=%d; HttpOnly; Secure; SameSite=None",
+                            newAccessToken,jwtProperties.getACCESS_TOKEN_EXPIRATION());
+                    response.addHeader("Set-Cookie", accessCookie);
 
                     // 인증 정보 설정
                     PrincipalDetails principalDetails = new PrincipalDetails(user);

--- a/mindscape-auth/src/main/java/likelion/team1/mindscape/security/oauth/OAuth2SuccessHandler.java
+++ b/mindscape-auth/src/main/java/likelion/team1/mindscape/security/oauth/OAuth2SuccessHandler.java
@@ -59,24 +59,25 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         redisRefreshTokenService.saveRefreshToken(user.getAccountId(), refreshToken,
                 jwtProperties.getREFRESH_TOKEN_EXPIRATION());
 
-        //JWT 토큰 httponly 쿠키에 저장
-        Cookie accessTokenCookie = new Cookie(JwtProperties.ACCESS_TOKEN_STRING, accessToken);
-        accessTokenCookie.setHttpOnly(true);
-        accessTokenCookie.setPath("/");
-        //cookie.setSecure(true);
+
+        String accessCookie = String.format(
+                "AccessToken=%s; Path=/; Max-Age=%d; HttpOnly; Secure; SameSite=None",
+                accessToken,jwtProperties.getACCESS_TOKEN_EXPIRATION());
 
 
-        Cookie refreshTokenCookie = new Cookie(JwtProperties.REFRESH_TOKEN_STRING, refreshToken);
-        refreshTokenCookie.setHttpOnly(true);
-        refreshTokenCookie.setPath("/");
+
+        String refreshCookie = String.format(
+                "RefreshToken=%s; Path=/; Max-Age=%d; HttpOnly; Secure; SameSite=None",
+                refreshToken, jwtProperties.getREFRESH_TOKEN_EXPIRATION());
+
 
         Cookie jsessionidCookie = new Cookie("JSESSIONID", null);
         jsessionidCookie.setMaxAge(0);
         jsessionidCookie.setPath("/");
 
 
-        response.addCookie(accessTokenCookie);
-        response.addCookie(refreshTokenCookie);
+        response.addHeader("Set-Cookie", accessCookie);
+        response.addHeader("Set-Cookie", refreshCookie);
         response.addCookie(jsessionidCookie);
 
         response.sendRedirect(redirectPageUrl);


### PR DESCRIPTION
## 🚧 작업 내용

기존 작업 사항
jwt 토큰생성 후 response 시, cookie에 담도록 설정
API 요청에 대해 모든 cors 허용 상태

수정 작업 사항
Set-Cookie 문자열 조작 방식으로 response 시, header에 추가해서 cookie에 담기도록 수정
API 요청에 대해 호스팅하고 있는 주소만 응답하도록 cors 수정